### PR TITLE
Fixed: key differences table not rendering issue in case study 8 of typescript 

### DIFF
--- a/_case_studies/TypeScript/08-null-vs-undefined.md
+++ b/_case_studies/TypeScript/08-null-vs-undefined.md
@@ -111,6 +111,7 @@ console.log(result); // Output: undefined
 ```
 
 ## Key Differences Table
+
 | Feature               | null                                 | undefined                         |
 |-----------------------|--------------------------------------|------------------------------------|
 | Meaning               | Explicitly no value                  | Not initialized                    |


### PR DESCRIPTION
### Summary
This PR fixes a rendering issue in the "Null vs Undefined" case study (`08-null-vs-undefined.md`) where the **Key Differences Table** was displaying as raw Markdown text instead of an HTML table.

### Problem
The Markdown parser failed to recognize the table because there was no empty line separating the section header (`## Key Differences Table`) from the table definition.

### Fix
I added a newline between the header and the table row definitions.

### Verification
- [x] Ran the project locally using `bundle exec jekyll serve`.
- [x] Verified that the table now renders correctly as a grid in the browser.

<img width="945" height="927" alt="Screenshot From 2026-01-25 03-40-38" src="https://github.com/user-attachments/assets/ad0893df-a14f-46f0-b3f0-4e47f2b23be5" />

<img width="980" height="1068" alt="Screenshot From 2026-01-25 02-15-04" src="https://github.com/user-attachments/assets/9a460250-c59d-433d-92a2-966de50c6335" />
