### PR TITLE
Add Blog: Rohit Kumar – Pinternship Journey

### DIFF
--- a/_blogs/Rohit_B_PinternshipWIN251043.md
+++ b/_blogs/Rohit_B_PinternshipWIN251043.md
@@ -1,0 +1,30 @@
+---
+title: "Learning Without a Safety Net: What the Pinternship Quietly Changed in Me"
+author: Rohit Kumar
+pinternship_id: WIN251043
+---
+
+When I joined the Pinternship with VLED Lab, I thought I was stepping into another learning program — one more course, one more line on my resume. What I didn’t realize was that this journey would quietly change how I think about learning, effort, and responsibility.
+
+This wasn’t a space where someone constantly told me what to do next. There was no checklist to hide behind. No illusion of progress created by just “finishing videos.” From the very beginning, learning demanded presence.
+
+The first shift happened during the ViBe-based learning. It felt uncomfortable at times — not because the content was impossible, but because there was nowhere to escape. If I didn’t understand something, I couldn’t skip it and move on guilt-free. The learning waited for me to show up properly. That was new.
+
+Then came the case studies. This is where I stopped feeling like a student and started feeling like a problem-solver — and sometimes, like someone completely stuck. There were moments where nothing worked, where logic felt messy, and where I questioned whether I was “good enough” to think this way. But slowly, through trial, discussion, and revisiting mistakes, I learned something far more valuable than syntax: how to sit with uncertainty without panicking.
+
+One of the most underrated parts of this journey was consistency. Not motivation. Not talent. Just showing up — even on days when progress felt invisible. I realized that growth doesn’t announce itself loudly. Most days, it feels like nothing is happening. And then one day, you notice that the problems that once scared you now feel… manageable.
+
+Working with others added another layer to this experience. Listening to different approaches, explaining my own thinking, being wrong in front of others — all of it reshaped how I view collaboration. It stopped being about proving myself and started being about learning together.
+
+Preparing for the viva was another mirror. It forced me to reflect not on what I memorized, but on what I actually understood. Feedback — sometimes subtle, sometimes direct — played a huge role here. I learned that feedback isn’t a judgment of who you are; it’s a signal of where you can grow next.
+
+If there’s one thing that stayed with me after this journey, it’s this: real learning doesn’t feel smooth. It feels slow, awkward, and deeply personal. But it’s also the kind that lasts.
+
+This Pinternship didn’t just teach me parts of the MERN stack. It taught me how to learn when there is no safety net — and how to trust the process even when the results aren’t immediate.
+
+And that’s something I’ll carry far beyond this program.
+
+---
+
+Author: [Rohit Kumar](https://www.linkedin.com/in/rohikumar99/){:target="_blank"}
+LinkedIn Article: [Read on LinkedIn](https://www.linkedin.com/pulse/learning-without-safety-net-what-pinternship-quietly-changed-kumar-dcmnc/){:target="_blank"}


### PR DESCRIPTION
This PR adds my personal blog reflecting on my learning journey during the Pinternship with VLED Lab.

LinkedIn Article:
https://www.linkedin.com/pulse/learning-without-safety-net-what-pinternship-quietly-changed-kumar-dcmnc/
