### PR TITLE
fix: removed {:target="_blank"} from end of file which has no use in blogs/Sample.md

### DIFF
--- a/_blogs/Sample_B_S12345.md
+++ b/_blogs/Sample_B_S12345.md
@@ -10,5 +10,5 @@ This is a sample blog to show you how the blogs render on the website.
 
 ---
 
-Author: [Mohit Kumar](https://www.linkedin.com/in/vled-lab/){:target="_blank"}
-LinkedIn Article: [Read on LinkedIn](https://www.linkedin.com/my-learning-journey-reflections-growth-vled-lab/){:target="_blank"}
+Author: [Mohit Kumar](https://www.linkedin.com/in/vled-lab/)
+LinkedIn Article: [Read on LinkedIn](https://www.linkedin.com/my-learning-journey-reflections-growth-vled-lab/)


### PR DESCRIPTION
The keyword has no use and is also not rendering , many interns used this and forgot to remove this while  writing there blog according to this file.
<img width="1920" height="928" alt="Screenshot From 2026-01-30 22-32-13" src="https://github.com/user-attachments/assets/114676f0-ba3f-41a0-a219-120c1a10f749" />
