### PR TITLE
feat: add blog post to _blog folder

### DIFF
--- a/_blogs/Ayush_B_VinternshipWIN25827.md
+++ b/_blogs/Ayush_B_VinternshipWIN25827.md
@@ -1,0 +1,36 @@
+---
+title: "From Tutorial Hell to Real-World Confidence: My Journey with VLED Lab"
+author: Ayush Mishra
+vinternship_id: WIN25827
+---
+
+## Introduction
+
+Before taking the internship with Vicharanashala Lab for Education Design Lab, I was not confident enough about my development journey. I learned from YouTube, watched tutorials, and got stuck in what you call tutorial hell. I even made mini projects, but the validation part—that someone sees your work and encourages you—was missing.
+
+## Case-Based Learning
+
+Vicharanashala Lab for Education Design Lab solved this by letting interns solve case studies that are based on real-life design patterns. I finally got to implement what I had learned in lectures through these case studies. I took help from Google and tech stack documentation because there are so many small things taught in lectures that you can’t remember everything at all times, so taking help from documentation felt natural.
+
+## Consistency and Discipline
+
+Discipline is another major part of the internship, as there are several milestones to hit before deadlines that you can’t fall behind on. Being active daily—whether on the VIBE platform or through solving case studies—makes you habitual to the work, and instead of fearing it, you embrace it and it becomes fun.
+
+## Technical Confidence
+
+For example, I had made MERN stack projects before using JavaScript and thought I would learn TypeScript someday, as it is an industry standard, and I always kind of feared it. But now that I have solved every case study and implemented TypeScript in my own project, I am confident enough to take on even bigger projects using TypeScript.
+
+## Growth and Collaboration
+
+Earlier, I confined my learning and hesitated to build my presence on LinkedIn, thinking that someday would come when I would post my achievements and work. That day came when I was selected for the internship. It helped me connect with people. Getting to work with others and share the problems you are working on through breakout rooms is just the cherry on top.
+
+## Conclusion
+
+Overall, the VLED Lab internship helped me move from passive learning to practical implementation. It gave me guidance, discipline, and confidence—both technically and professionally. What once felt overwhelming now feels approachable, and now I am more prepared and motivated to take on bigger challenges ahead.
+
+Grateful to Vicharanashala Lab for Education Design, ANNAM.AI, Sudarshan Iyengar, and my fellow interns for the learning, support, and collaboration throughout this internship. Excited to build further and take on new challenges.
+
+---
+
+Author: [Ayush Mishra](https://www.linkedin.com/in/ayush-mishra-2072961a3/){:target="_blank"}  
+LinkedIn Article: [Read on LinkedIn](https://www.linkedin.com/pulse/from-tutorial-hell-real-world-confidence-my-journey-vled-ayush-mishra-b6dwc/){:target="_blank"}


### PR DESCRIPTION
This PR includes my Activity A3 blog for VLED Lab, sharing reflections and insights gained through the task. The post has been added to the _blog/ directory following the naming format.